### PR TITLE
Fixe old dependencies url

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,9 +9,9 @@ environment:
 # Add regular dependencies here.
 dependencies:
   opencv_ffi: 
-    git: https://github.com/BinghamtonRover/OpenCV-FFI
+    git: https://github.com/Levi-Lesches/opencv_ffi
   burt_network: 
-    git: https://github.com/BinghamtonRover/Dart-Networking
+    git: https://github.com/BinghamtonRover/Networking
 
 dev_dependencies:
   test: ^1.21.0
@@ -20,8 +20,8 @@ dev_dependencies:
 # This section is for the rover only. On your own system, comment this out.
 # (This tells Pub/Dart to find these packages in nearby folders, rather than
 # from GitHub, so that we can run without Internet access).
-dependency_overrides: 
-  opencv_ffi: 
+dependency_overrides:
+  opencv_ffi:
     path: ../opencv_ffi
-  burt_network: 
+  burt_network:
     path: ../burt_network


### PR DESCRIPTION
`dependency_overrides` is crashing ci

Would recommend creating a `dependency_overrides` file and put it in your gitignore for your own use.


Also downloading packages in only while developing, if you are compiling your code `dart compile exe` the file should already include the downloaded packages and will run faster 

> # from GitHub, so that we can run without Internet access).