### PR TITLE
Add onboard screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ dist/
 camera_details/
 # Camera calibrations
 calibrations/
+# Screenshots
+screenshots/

--- a/lib/src/collection.dart
+++ b/lib/src/collection.dart
@@ -34,7 +34,6 @@ class Collection extends Service {
     await cameras.dispose();
     await lidar.dispose();
     await videoServer.dispose();
-    exit(0);
   }
 }
 

--- a/lib/src/collection.dart
+++ b/lib/src/collection.dart
@@ -1,5 +1,4 @@
 import "dart:async";
-import "dart:io";
 
 import "package:burt_network/burt_network.dart";
 import "package:video/src/lidar.dart";

--- a/lib/src/collection.dart
+++ b/lib/src/collection.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:io";
 
 import "package:burt_network/burt_network.dart";
 import "package:video/src/lidar.dart";
@@ -33,6 +34,7 @@ class Collection extends Service {
     await cameras.dispose();
     await lidar.dispose();
     await videoServer.dispose();
+    exit(0);
   }
 }
 

--- a/lib/src/isolates/child.dart
+++ b/lib/src/isolates/child.dart
@@ -122,7 +122,12 @@ abstract class CameraIsolate extends IsolateChild<IsolatePayload, VideoCommand> 
         } else {
           sendLog(Level.error, "Failed to take screenshot");
         }
-      } catch (_) {
+      } catch (e) {
+        sendLog(
+          Level.error,
+          "Error while taking screenshot",
+          body: e.toString(),
+        );
         isReadingFrame = false;
       }
     } else {

--- a/lib/src/isolates/child.dart
+++ b/lib/src/isolates/child.dart
@@ -104,12 +104,12 @@ abstract class CameraIsolate extends IsolateChild<IsolatePayload, VideoCommand> 
     }
   }
 
-  /// Takes a high quality, onboard image and saves it to a shared folder
+  /// Takes a high quality onboard image and saves it to a shared folder
   ///
-  /// This is highly blocking, calling the [getScreenshotJpeg] to get a high quality image,
+  /// This calls the [getScreenshotJpeg] obtain a high quality image,
   /// and saves it to [baseDirectory]/shared
   ///
-  /// This should only be called on command
+  /// This is highly blocking, and should only be called when a command is received
   Future<void> takeSnapshot() async {
     if (isReadingFrame) {
       sendLog(

--- a/lib/src/isolates/child.dart
+++ b/lib/src/isolates/child.dart
@@ -102,7 +102,7 @@ abstract class CameraIsolate extends IsolateChild<IsolatePayload, VideoCommand> 
       final jpegData = await getScreenshotJpeg();
       isReadingFrame = false;
       if (jpegData != null) {
-        final baseDirectory = Platform.isLinux ? "/home/pi/shared" : "";
+        final baseDirectory = Platform.isLinux ? "/home/pi/shared" : Directory.current.path;
         final screenshotDirectory = "/screenshots/${name.name}";
         final directory = Directory(baseDirectory + screenshotDirectory);
 

--- a/lib/src/isolates/opencv.dart
+++ b/lib/src/isolates/opencv.dart
@@ -172,6 +172,9 @@ class OpenCVCameraIsolate extends CameraIsolate {
     final originalWbTemp = camera!.get(CAP_PROP_WB_TEMPERATURE);
     final originalAutoWb = camera!.get(CAP_PROP_AUTO_WB);
 
+    camera!.dispose();
+    camera = getCamera(name);
+
     camera!.setResolution(width: 10000, height: 10000);
 
     camera!.fps = 0;
@@ -186,10 +189,13 @@ class OpenCVCameraIsolate extends CameraIsolate {
     camera!.set(CAP_PROP_WB_TEMPERATURE, originalWbTemp);
 
     for (int i = 0; i < 3; i++) {
-      camera!.grab();
+      await camera!.grabAsync();
     }
 
     final (success, matrix) = await camera!.readAsync();
+    
+    camera!.dispose();
+    camera = getCamera(name);
 
     camera!.setResolution(width: originalWidth, height: originalHeight);
     camera!.fps = originalFps;

--- a/lib/src/isolates/opencv.dart
+++ b/lib/src/isolates/opencv.dart
@@ -18,6 +18,7 @@ class OpenCVCameraIsolate extends CameraIsolate {
   @override
   void initCamera() {
     camera = getCamera(name);
+    camera!.set(CAP_PROP_FOURCC, VideoCapture.toCodec("MJPG"));
     camera?.setResolution(width: details.resolutionWidth, height: details.resolutionHeight);
     frameProperties = FrameProperties.fromFrameDetails(
       captureWidth: camera!.width,
@@ -167,6 +168,7 @@ class OpenCVCameraIsolate extends CameraIsolate {
     camera!.dispose();
     camera = getCamera(name);
 
+    camera!.set(CAP_PROP_FOURCC, VideoCapture.toCodec("MJPG"));
     camera!.setResolution(width: 10000, height: 10000);
 
     camera!.fps = 0;
@@ -189,6 +191,7 @@ class OpenCVCameraIsolate extends CameraIsolate {
     camera!.dispose();
     camera = getCamera(name);
 
+    camera!.set(CAP_PROP_FOURCC, VideoCapture.toCodec("MJPG"));
     camera!.setResolution(width: originalWidth, height: originalHeight);
     camera!.fps = details.fps;
     if (details.hasZoom()) camera!.zoom = details.zoom;

--- a/lib/src/isolates/opencv.dart
+++ b/lib/src/isolates/opencv.dart
@@ -150,4 +150,19 @@ class OpenCVCameraIsolate extends CameraIsolate {
     sendFrame(frame);
     fpsCount++;
   }
+
+  @override
+  Uint8List? getJpegData() {
+    if (camera == null) {
+      return null;
+    }
+    camera!.grab();
+    final (success, matrix) = camera!.read();
+    if (!success) return null;
+
+    final frame = matrix.encodeJpg(quality: details.quality);
+    matrix.dispose();
+
+    return frame;
+  }
 }

--- a/lib/src/isolates/opencv.dart
+++ b/lib/src/isolates/opencv.dart
@@ -1,4 +1,3 @@
-import "dart:io";
 import "dart:typed_data";
 
 import "package:dartcv4/dartcv.dart";
@@ -165,14 +164,6 @@ class OpenCVCameraIsolate extends CameraIsolate {
     final originalWidth = camera!.get(CAP_PROP_FRAME_WIDTH).toInt();
     final originalHeight = camera!.get(CAP_PROP_FRAME_HEIGHT).toInt();
 
-    final originalFps = camera!.fps;
-
-    final originalExposure = camera!.get(CAP_PROP_EXPOSURE);
-    final originalAutoExposure = camera!.get(CAP_PROP_AUTO_EXPOSURE);
-
-    final originalWbTemp = camera!.get(CAP_PROP_WB_TEMPERATURE);
-    final originalAutoWb = camera!.get(CAP_PROP_AUTO_WB);
-
     camera!.dispose();
     camera = getCamera(name);
 
@@ -182,12 +173,6 @@ class OpenCVCameraIsolate extends CameraIsolate {
     if (details.hasZoom()) camera!.zoom = details.zoom;
     if (details.hasFocus()) camera!.focus = details.focus;
     camera!.autofocus = details.autofocus;
-
-    camera!.set(CAP_PROP_AUTO_EXPOSURE, Platform.isWindows ? 1 : 3);
-    camera!.set(CAP_PROP_EXPOSURE, originalExposure);
-
-    camera!.set(CAP_PROP_AUTO_WB, Platform.isWindows ? 0 : 1);
-    camera!.set(CAP_PROP_WB_TEMPERATURE, originalWbTemp);
 
     final captureStart = DateTime.timestamp();
 
@@ -205,28 +190,10 @@ class OpenCVCameraIsolate extends CameraIsolate {
     camera = getCamera(name);
 
     camera!.setResolution(width: originalWidth, height: originalHeight);
-    camera!.fps = originalFps;
+    camera!.fps = details.fps;
     if (details.hasZoom()) camera!.zoom = details.zoom;
     if (details.hasFocus()) camera!.focus = details.focus;
     camera!.autofocus = details.autofocus;
-
-    // For some reason on windows the auto exposure and wb returns -1 which causes strange issues
-    camera!.set(
-      CAP_PROP_AUTO_EXPOSURE,
-      originalAutoExposure >= 0
-          ? originalAutoExposure
-          : Platform.isWindows
-              ? 1
-              : 3,
-    );
-    camera!.set(
-      CAP_PROP_AUTO_WB,
-      originalAutoWb >= 0
-          ? originalAutoWb
-          : Platform.isWindows
-              ? 1
-              : 3,
-    );
 
     if (!success) return null;
 

--- a/lib/src/isolates/opencv.dart
+++ b/lib/src/isolates/opencv.dart
@@ -24,6 +24,11 @@ class OpenCVCameraIsolate extends CameraIsolate {
       captureHeight: camera!.height,
       details: details,
     );
+    if (details.hasFps()) camera?.fps = details.fps;
+    if (details.hasZoom()) camera?.zoom = details.zoom;
+    if (details.hasFocus()) camera?.focus = details.focus;
+    camera?.autofocus = details.autofocus;
+
     if (!camera!.isOpened) {
       sendLog(LogLevel.warning, "Camera $name is not connected");
       updateDetails(CameraDetails(status: CameraStatus.CAMERA_DISCONNECTED), save: false);
@@ -57,8 +62,8 @@ class OpenCVCameraIsolate extends CameraIsolate {
     if (details.hasFocus() && details.focus != camera!.focus) {
       camera!.focus = details.focus;
     }
-    if (details.hasAutofocus() && details.autofocus != (camera!.autofocus == 1)) {
-      camera!.autofocus = details.focus;
+    if (details.hasAutofocus() && details.autofocus != camera!.autofocus) {
+      camera!.autofocus = details.autofocus;
     }
     if (frameProperties == null ||
         (newDetails.hasDiagonalFov() && newDetails.diagonalFov != frameProperties!.diagonalFoV) ||
@@ -152,15 +157,51 @@ class OpenCVCameraIsolate extends CameraIsolate {
   }
 
   @override
-  Uint8List? getJpegData() {
+  Future<Uint8List?> getScreenshotJpeg() async {
     if (camera == null) {
       return null;
     }
-    camera!.grab();
-    final (success, matrix) = camera!.read();
+    final originalWidth = camera!.get(CAP_PROP_FRAME_WIDTH).toInt();
+    final originalHeight = camera!.get(CAP_PROP_FRAME_HEIGHT).toInt();
+
+    final originalFps = camera!.fps;
+
+    final originalExposure = camera!.get(CAP_PROP_EXPOSURE);
+    final originalAutoExposure = camera!.get(CAP_PROP_AUTO_EXPOSURE);
+
+    final originalWbTemp = camera!.get(CAP_PROP_WB_TEMPERATURE);
+    final originalAutoWb = camera!.get(CAP_PROP_AUTO_WB);
+
+    camera!.setResolution(width: 10000, height: 10000);
+
+    camera!.fps = 0;
+    if (details.hasZoom()) camera!.zoom = details.zoom;
+    if (details.hasFocus()) camera!.focus = details.focus;
+    camera!.autofocus = details.autofocus;
+
+    camera!.set(CAP_PROP_AUTO_EXPOSURE, 3);
+    camera!.set(CAP_PROP_EXPOSURE, originalExposure);
+
+    camera!.set(CAP_PROP_AUTO_WB, 1);
+    camera!.set(CAP_PROP_WB_TEMPERATURE, originalWbTemp);
+
+    for (int i = 0; i < 3; i++) {
+      camera!.grab();
+    }
+
+    final (success, matrix) = await camera!.readAsync();
+
+    camera!.setResolution(width: originalWidth, height: originalHeight);
+    camera!.fps = originalFps;
+    if (details.hasZoom()) camera!.zoom = details.zoom;
+    if (details.hasFocus()) camera!.focus = details.focus;
+    camera!.autofocus = details.autofocus;
+    camera!.set(CAP_PROP_AUTO_EXPOSURE, originalAutoExposure);
+    camera!.set(CAP_PROP_AUTO_WB, originalAutoWb);
+
     if (!success) return null;
 
-    final frame = matrix.encodeJpg(quality: details.quality);
+    final frame = matrix.encodeJpg(quality: 100);
     matrix.dispose();
 
     return frame;

--- a/lib/src/isolates/parent.dart
+++ b/lib/src/isolates/parent.dart
@@ -81,14 +81,20 @@ class CameraManager extends Service {
   /// - If a [LogPayload] comes, logs the message using [logger].
   void onData(IsolatePayload data) {
     switch (data) {
-      case FramePayload(:final image, :final details):
+      case FramePayload(:final details, :final image, :final screenshotPath):
         if (data.details.name == findObjectsInCameraFeed) {
           // Feeds from this camera get sent to the vision program.
           // The vision program will detect objects and send metadata to Autonomy.
           // The frames will be annotated and sent back here. See [_handleVision].
           collection.videoServer.sendMessage(VideoData(frame: image, details: details), destination: cvSocket);
         } else {
-          collection.videoServer.sendMessage(VideoData(frame: image, details: details));
+          collection.videoServer.sendMessage(
+            VideoData(
+              frame: image,
+              details: details,
+              imagePath: screenshotPath,
+            ),
+          );
         }
       case DepthFramePayload():
         collection.videoServer.sendMessage(VideoData(frame: data.frame.depthFrame), destination: autonomySocket);

--- a/lib/src/isolates/parent.dart
+++ b/lib/src/isolates/parent.dart
@@ -86,7 +86,13 @@ class CameraManager extends Service {
           // Feeds from this camera get sent to the vision program.
           // The vision program will detect objects and send metadata to Autonomy.
           // The frames will be annotated and sent back here. See [_handleVision].
-          collection.videoServer.sendMessage(VideoData(frame: image, details: details), destination: cvSocket);
+          collection.videoServer.sendMessage(
+            VideoData(
+              frame: image,
+              details: details,
+            ),
+            destination: cvSocket,
+          );
         } else {
           collection.videoServer.sendMessage(
             VideoData(

--- a/lib/src/isolates/payload.dart
+++ b/lib/src/isolates/payload.dart
@@ -23,8 +23,11 @@ class FramePayload extends IsolatePayload {
   /// The image to send.
   final Uint8List? image;
 
+  /// The path of the screenshot
+  String? screenshotPath;
+
   /// A const constructor.
-  FramePayload({required this.details, this.image});
+  FramePayload({required this.details, this.image, this.screenshotPath});
 }
 
 /// A class to send log messages across isolates. The parent isolate is responsible for logging.

--- a/lib/src/isolates/realsense.dart
+++ b/lib/src/isolates/realsense.dart
@@ -102,6 +102,25 @@ class RealSenseIsolate extends CameraIsolate {
 
     colorizedImage.dispose();
   }
+
+  @override
+  Uint8List? getJpegData() {
+    // Get frames from RealSense
+    final frames = camera.getFrames();
+    if (frames == nullptr) return null;
+
+    // Compress colorized frame
+    final Pointer<Uint8> rawColorized = frames.ref.colorized_data;
+    if (rawColorized == nullptr) return null;
+    final colorizedMatrix = rawColorized.toOpenCVMat(camera.depthResolution, length: frames.ref.colorized_length);
+    final colorizedJpg = colorizedMatrix.encodeJpg(quality: details.quality);
+
+    colorizedMatrix.dispose();
+    frames.dispose();
+
+    return colorizedJpg;
+  }
+
   /// Sends the RealSense's RGB frame and optionally detects ArUco tags.
   Future<void> sendRgbFrame(Pointer<NativeFrames> rawFrames) async {
     final rawRGB = rawFrames.ref.rgb_data;

--- a/lib/src/isolates/realsense.dart
+++ b/lib/src/isolates/realsense.dart
@@ -104,7 +104,7 @@ class RealSenseIsolate extends CameraIsolate {
   }
 
   @override
-  Uint8List? getJpegData() {
+  Future<Uint8List?> getScreenshotJpeg() async {
     // Get frames from RealSense
     final frames = camera.getFrames();
     if (frames == nullptr) return null;

--- a/lib/src/utils/opencv.dart
+++ b/lib/src/utils/opencv.dart
@@ -52,8 +52,8 @@ extension VideoCaptureUtils on VideoCapture {
   set roll(int value) => set(35, value.toDouble());
 
   /// Determines whether autofocus is on or off
-  int get autofocus => get(39).toInt();
-  set autofocus(int value) => set(39, value.toDouble());
+  bool get autofocus => get(39) == 1;
+  set autofocus(bool value) => set(39, value ? 1 : 0);
 }
 
 /// Useful methods on OpenCV images.

--- a/src/realsense_ffi.cpp
+++ b/src/realsense_ffi.cpp
@@ -38,6 +38,7 @@ BurtRsConfig RealSense_getDeviceConfig(NativeRealSense* ptr) {
 BurtRsStatus RealSense_startStream(NativeRealSense* ptr) {
   return reinterpret_cast<burt_rs::RealSense*>(ptr)->startStream();
 }
+
 void RealSense_stopStream(NativeRealSense* ptr) {
   reinterpret_cast<burt_rs::RealSense*>(ptr)->stopStream();
 }

--- a/src/realsense_ffi.h
+++ b/src/realsense_ffi.h
@@ -66,5 +66,5 @@ FFI_PLUGIN_EXPORT NativeFrames* RealSense_getDepthFrame(NativeRealSense* ptr);
 FFI_PLUGIN_EXPORT void NativeFrames_free(NativeFrames* ptr);
 
 #ifdef __cplusplus
-}
+} // extern "C"
 #endif

--- a/src/realsense_internal.cpp
+++ b/src/realsense_internal.cpp
@@ -46,7 +46,6 @@ const char* burt_rs::RealSense::getDeviceName() {
 }
 
 // -------------------- Stream methods --------------------
-
 BurtRsStatus burt_rs::RealSense::startStream() {
   rs2::config rs_config;
   rs_config.enable_stream(RS2_STREAM_DEPTH, DEPTH_WIDTH, HEIGHT);
@@ -62,8 +61,7 @@ BurtRsStatus burt_rs::RealSense::startStream() {
 
   streaming = hasDevice;
 
-  // if (rgb_width == 0 || rgb_height == 0 || depth_width == 0 || depth_height == 0) {
-  if (depth_width == 0 || depth_height == 0) {
+  if (rgb_width == 0 || rgb_height == 0 || depth_width == 0 || depth_height == 0) {
     return BurtRsStatus::BurtRsStatus_resolution_unknown;
   } else {
     config.depth_width = depth_width;
@@ -91,9 +89,6 @@ NativeFrames* burt_rs::RealSense::getDepthFrame() {
   if (!pipeline.poll_for_frames(&frames)) return nullptr;
   rs2::depth_frame depth_frame = frames.get_depth_frame();
   rs2::frame colorized_frame = colorizer.colorize(depth_frame);
-
-  rs2::frameset aligned_frames = align.process(frames);
-  rs2::depth_frame aligned_depth_frame = aligned_frames.get_depth_frame();
   rs2::frame rgb_frame = frames.get_color_frame();
 
   // Copy frames into a new uint8_t[]

--- a/src/realsense_internal.cpp
+++ b/src/realsense_internal.cpp
@@ -34,10 +34,6 @@ BurtRsStatus burt_rs::RealSense::init() {
     config.scale = scale;
   }
   hasDevice = true;
-  // disable IR lasers (for safety purposes)
-  if (sensor.supports(RS2_OPTION_LASER_POWER)) {
-    sensor.set_option(RS2_OPTION_LASER_POWER, 0.f);
-  }
 
   return BurtRsStatus::BurtRsStatus_ok;
 }

--- a/src/realsense_internal.cpp
+++ b/src/realsense_internal.cpp
@@ -34,6 +34,11 @@ BurtRsStatus burt_rs::RealSense::init() {
     config.scale = scale;
   }
   hasDevice = true;
+  // disable IR lasers (for safety purposes)
+  if (sensor.supports(RS2_OPTION_LASER_POWER)) {
+    sensor.set_option(RS2_OPTION_LASER_POWER, 0.f);
+  }
+
   return BurtRsStatus::BurtRsStatus_ok;
 }
 
@@ -50,6 +55,7 @@ BurtRsStatus burt_rs::RealSense::startStream() {
   rs2::config rs_config;
   rs_config.enable_stream(RS2_STREAM_DEPTH, DEPTH_WIDTH, HEIGHT);
   rs_config.enable_stream(RS2_STREAM_COLOR, RGB_WIDTH, HEIGHT, RS2_FORMAT_BGR8);
+
   auto profile = pipeline.start(rs_config);
   auto frames = pipeline.wait_for_frames();
   auto depth_frame = frames.get_depth_frame();
@@ -74,6 +80,9 @@ BurtRsStatus burt_rs::RealSense::startStream() {
 
 void burt_rs::RealSense::stopStream() {
   pipeline.stop();
+  for (auto sensor : device.query_sensors()) {
+    sensor.close();
+  }
   streaming = false;
   hasDevice = false;
 }

--- a/src/realsense_internal.cpp
+++ b/src/realsense_internal.cpp
@@ -94,6 +94,9 @@ NativeFrames* burt_rs::RealSense::getDepthFrame() {
   if (!pipeline.poll_for_frames(&frames)) return nullptr;
   rs2::depth_frame depth_frame = frames.get_depth_frame();
   rs2::frame colorized_frame = colorizer.colorize(depth_frame);
+
+  rs2::frameset aligned_frames = align.process(frames);
+  rs2::depth_frame aligned_depth_frame = aligned_frames.get_depth_frame();
   rs2::frame rgb_frame = frames.get_color_frame();
 
   // Copy frames into a new uint8_t[]


### PR DESCRIPTION
If a video command is sent and `takeScreenshot` is true, the camera will temporarily re-open with max quality and resolution, and save the image to a screenshots directory. On the Raspberry Pi, a network drive will be hosted in the `shared` directory, which can be accessed through windows while connected to the rover.